### PR TITLE
Add CI workflow and test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run tests
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build"
+    "build": "astro build",
+    "test": "pnpm build"
   },
   "dependencies": {
     "astro": "^5.9.0"


### PR DESCRIPTION
## Summary
- add a `test` script that runs the build
- set up a GitHub Actions workflow to run `pnpm install` and `pnpm test` on PRs

## Testing
- `pnpm install` *(fails: fetch from registry blocked)*
- `pnpm test` *(fails: fetch from registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6846a942e690832b84859c1e4c00a488