### PR TITLE
Fix content slug handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 node_modules/
 dist/
 .build/
-src/content/docs/en/*
-src/content/docs/jp/*
-src/content/docs/kr/*
 .env
 .astro/

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,6 +5,9 @@ const docs = defineCollection({
     title: z.string(),
     lang: z.enum(["kr", "en", "jp"]),
   }),
+  // Remove the `.md` extension when generating slugs so they match the route
+  // parameters used with `getEntry()`.
+  slug: ({ id }) => id.replace(/\.md$/, ""),
 });
 
 export const collections = { docs };

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,11 +1,11 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection, z } from 'astro:content';
 
 const docs = defineCollection({
   schema: z.object({
     title: z.string(),
-    lang: z.enum(["kr", "en", "jp"]),
+    lang: z.enum(['kr', 'en', 'jp']),
   }),
-  slug: ({ id }) => id.replace(/\.md$/, ""), // ✅ 이 줄이 핵심
+  slug: ({ id }) => id.replace(/\.md$/, ''),
 });
 
 export const collections = { docs };

--- a/src/content/docs/en/index.md
+++ b/src/content/docs/en/index.md
@@ -1,0 +1,8 @@
+---
+title: Welcome English
+lang: en
+---
+
+# Hello world
+
+This is the English index page.

--- a/src/content/docs/kr/index.md
+++ b/src/content/docs/kr/index.md
@@ -1,0 +1,8 @@
+---
+title: Korean index
+lang: kr
+---
+
+# 안녕하세요
+
+한국어 인덱스 페이지입니다.

--- a/src/pages/docs/[locale]/[...slug].astro
+++ b/src/pages/docs/[locale]/[...slug].astro
@@ -3,41 +3,29 @@ import { getEntry, getCollection } from 'astro:content';
 import DocLayout from '@/layouts/DocLayout.astro';
 
 const { locale, slug } = Astro.params ?? {};
-console.log('Astro.params:', Astro.params);
-if (!locale || !slug) throw new Error(`Missing route parameters`);
-const slugPath = Array.isArray(slug) ? slug.join('/') : slug;
-const id = `${locale}/${slugPath}.md`;
-const docs = await getCollection('docs');
-
-const matched = docs.find((d) => d.id === id);
-
-if (!matched) {
-  throw new Error(`Document not found via getCollection: ${id}`);
+if (!locale) {
+  throw new Error(`Missing route parameters`);
 }
-
-const rendered = await matched.render();
-const { Content, data } = rendered;
+const slugPath = Array.isArray(slug) ? slug.join('/') : (slug ?? '');
+// If no slug was provided (index route), use 'index'
+const entrySlug = slugPath === '' ? `${locale}/index` : `${locale}/${slugPath}`;
+const { Content, data } = await (await getEntry('docs', entrySlug)).render();
 
 export async function getStaticPaths() {
   const docs = await getCollection('docs');
-  console.log(docs.map(d => d.id))
 
   return docs.map((doc) => {
-  const cleanId = doc.id.replace(/\.md$/, '');
-  const [locale, ...slugParts] = cleanId.split('/');
+    const [locale, ...slugParts] = doc.slug.split('/');
+    const slug = slugParts.length === 1 && slugParts[0] === 'index'
+      ? undefined
+      : slugParts.length <= 1
+        ? slugParts[0]
+        : slugParts;
 
-  // ✅ index.md → slugParts = [] ← 이때 slug가 없어짐
-  const slug = slugParts.length === 0
-    ? [] // Astro가 /docs/kr/ 같은 경로로 인식하게 만듦
-    : slugParts.length === 1
-      ? slugParts[0]
-      : slugParts;
-
-  return {
-    params: { locale, slug },
-  };
-});
-
+    return {
+      params: { locale, slug },
+    };
+  });
 }
 
 ---


### PR DESCRIPTION
## Summary
- update content collection config with slug formatting
- adjust docs page to load via `getEntry`
- remove docs from gitignore and add example docs

## Testing
- `npx astro build` *(fails: Entry docs → kr/index was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bf993e38832bbde32800694fa0c3